### PR TITLE
feat: add roadmap phases and codex prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,8 @@ tests, and build checks before Vercel deploys.
 - Blog system with WYSIWYG editor
 - Dark/light theme with Tailwind CSS
 - Agent-ready architecture (see `agents/`)
+
+## Codex System Overview
+- Agents live under `agents/` and log actions to `logs.json`.
+- Reusable prompts are stored in `codex-prompts/` for Codex workflows.
+- `pnpm tsx agents/roadmap-agent.ts` audits roadmap items and phases.

--- a/agents/sop/guardian-agent.md
+++ b/agents/sop/guardian-agent.md
@@ -1,18 +1,30 @@
 # guardian-agent
 
 ## Purpose
-Guardian agent: detect secrets or risky code
+Monitor repository for secrets, ethical risk, and policy violations.
 
 ## Expected Inputs
 - Run via `pnpm tsx agents/guardian-agent.ts`
+- Receives a diff or file paths to scan.
 
 ## Expected Outputs
-- Logs actions to logs.json
+- Logs detected issues to `logs.json`.
+- Returns non-zero exit code on critical findings.
+
+## Guidelines
+- Scan for `NEXT_PUBLIC_` variables and hardcoded API keys.
+- Flag files with TODOs in security-sensitive areas.
+- Respect `.gitignore` and skip `node_modules`.
 
 ## Example Log Output
 ```json
 {
   "agent": "guardian-agent",
-  "action": "example"
+  "action": "scan",
+  "issues": []
 }
 ```
+
+## Escalation
+- Post a PR comment when secrets are detected.
+- Notify maintainers via issue if ethical guidelines are breached.

--- a/analysis/roadmap.md
+++ b/analysis/roadmap.md
@@ -1,0 +1,34 @@
+# 30/60/90 Day Roadmap
+
+## Engineering
+### 30 Day
+- Integrate dotenv schema validation for environment variables.
+- Add vitest unit tests for agents.
+### 60 Day
+- Build Supabase-backed blog UI and admin dashboard.
+- Implement CI lint and test gating with coverage thresholds.
+### 90 Day
+- Launch live metrics panel and performance monitoring.
+- Harden auth flows and role-based access.
+
+## Infra
+### 30 Day
+- Configure secret scanning and guardian-agent alerts in CI.
+- Add script to provision Supabase storage in setup.sh.
+### 60 Day
+- Implement error-catching middleware for agents.
+- Introduce staging environment via Vercel preview.
+### 90 Day
+- Automate backup/restore for Supabase.
+- Optimize CDN caching and image pipeline.
+
+## AI Ops
+### 30 Day
+- Finalize SOPs for all agents and codex prompts for testing.
+- Enable roadmap-agent to track 30/60/90 tasks.
+### 60 Day
+- Deploy secret validation agent and ethics dashboard.
+- Start automated Codex prompt review loops.
+### 90 Day
+- Expand guardian-agent with anomaly detection.
+- Iterate on AI-driven opportunity engine.

--- a/codex-prompts/ci-secret-hygiene.md
+++ b/codex-prompts/ci-secret-hygiene.md
@@ -1,0 +1,8 @@
+# CI Secret Hygiene
+
+- Inspect `.github/workflows/` and `lib/env.ts`.
+- Add dotenv schema validation using a library like `zod` or `envalid`.
+- Implement a secret validation agent that runs in CI.
+- Ensure `lib/env.ts` throws on missing or malformed variables.
+- Propose PR comments when `NEXT_PUBLIC_*` or hardcoded secrets are detected.
+- Add error-catching logic in workflows to abort on secret leaks.

--- a/codex-prompts/init-vitest-for-codex-planner.md
+++ b/codex-prompts/init-vitest-for-codex-planner.md
@@ -1,0 +1,5 @@
+# Init Vitest for codex-planner
+
+- Add `tests/codex-planner.test.ts` covering roadmap suggestion logic.
+- Mock file inputs and ensure outputs logged to `logs.json`.
+- Use snapshots for planner responses.

--- a/codex-prompts/init-vitest-for-guardian-agent.md
+++ b/codex-prompts/init-vitest-for-guardian-agent.md
@@ -1,0 +1,6 @@
+# Init Vitest for guardian-agent
+
+- Create `tests/guardian-agent.test.ts`.
+- Mock file system inputs to ensure secret detection.
+- Assert that the agent exits with an error when secrets are found.
+- Update `npm test` to include the new test.

--- a/codex-prompts/init-vitest-for-roadmap-agent.md
+++ b/codex-prompts/init-vitest-for-roadmap-agent.md
@@ -1,0 +1,6 @@
+# Init Vitest for roadmap-agent
+
+- Create `tests/roadmap-agent.test.ts`.
+- Provide sample roadmap markdown and ensure parsing produces phases.
+- Verify logging of incomplete tasks.
+- Include coverage in `npm test` script.

--- a/codex-prompts/init-vitest-for-sop-agent.md
+++ b/codex-prompts/init-vitest-for-sop-agent.md
@@ -1,0 +1,5 @@
+# Init Vitest for sop-agent
+
+- Create `tests/sop-agent.test.ts`.
+- Mock SOP templates and verify generation for missing agents.
+- Assert logs contain created SOP entries.

--- a/codex-prompts/live-metrics-panel.md
+++ b/codex-prompts/live-metrics-panel.md
@@ -1,0 +1,5 @@
+# Live Metrics Panel
+
+- Query Supabase `analytics` table using real-time subscriptions.
+- Render charts with `react-chartjs-2`.
+- Show current active users and recent events.

--- a/codex-prompts/render-admin-dashboard.md
+++ b/codex-prompts/render-admin-dashboard.md
@@ -1,0 +1,6 @@
+# Render Admin Dashboard
+
+- Create `/app/admin` route with Supabase auth guard.
+- Display tables for posts and users with edit/delete actions.
+- Use Tailwind CSS and existing components.
+- Include metrics panel for recent activity.

--- a/codex-prompts/supabase-blog-ui.md
+++ b/codex-prompts/supabase-blog-ui.md
@@ -1,0 +1,5 @@
+# Supabase Blog UI
+
+- Build blog listing and post detail pages powered by Supabase.
+- Use server components to fetch posts.
+- Add pagination and WYSIWYG editor support.

--- a/codex-prompts/write-sop-for-imported-guardian-agent.md
+++ b/codex-prompts/write-sop-for-imported-guardian-agent.md
@@ -1,0 +1,5 @@
+# Write SOP for imported-guardian-agent
+
+- Document purpose and differences from `guardian-agent`.
+- Define inputs, outputs, and logging format.
+- Include escalation steps for secret or ethics violations.

--- a/logs/flows/2025-08-04-roadmap.log
+++ b/logs/flows/2025-08-04-roadmap.log
@@ -1,0 +1,3 @@
+- Updated roadmap-agent for 30/60/90-day phases.
+- Added guardian-agent SOP details.
+- Created codex prompts for CI hygiene, vitest setups, and UI features.


### PR DESCRIPTION
## Summary
- add 30/60/90-day roadmap and parser for roadmap-agent
- refine guardian-agent SOP for ethical secret monitoring
- add Codex prompt stubs for CI hygiene, vitest scaffolds, UI panels, and SOPs

## Testing
- `npm install` *(fails: ERESOLVE could not resolve)*
- `npm install --legacy-peer-deps` *(fails: No matching version for @supabase/auth-helpers-react@^0.4.7)*
- `npm test` *(fails: vitest: not found)*
- `npm run lint` *(fails: next: not found)*
- `bash scripts/setup.sh`

------
https://chatgpt.com/codex/tasks/task_e_6891a2dd85dc8323aec9e8d99ac0349e